### PR TITLE
Enable Markdown in summary

### DIFF
--- a/layouts/partials/summary.html
+++ b/layouts/partials/summary.html
@@ -8,7 +8,7 @@
                         {{ end }}
 
                         <div class="media-body text-left">
-                            <p class="mb-0">{{ .Site.Params.summary.text }}</p>
+                            <p class="mb-0">{{ .Site.Params.summary.text | markdownify }}</p>
                         </div><!--//media-body-->
 
                     </div>


### PR DESCRIPTION
I need to add link in summary, but neither HTML or Markdown are currently allowed.

This PR enables using Markdown in summary text.