### PR TITLE
Enable Markdown for Company names

### DIFF
--- a/layouts/partials/experience.html
+++ b/layouts/partials/experience.html
@@ -7,7 +7,7 @@
                                 <div class="item mb-3">
                                     <div class="item-heading row align-items-center mb-2">
                                         <h4 class="item-title col-12 col-md-6 col-lg-6 mb-2 mb-md-0">{{ .title }}</h4>
-                                        <div class="item-meta col-12 col-md-6 col-lg-6 text-muted text-left text-md-right">{{ .company }} | {{ .dates }}</div>
+                                    <div class="item-meta col-12 col-md-6 col-lg-6 text-muted text-left text-md-right">{{ .company | markdownify }} | {{ .dates }}</div>
                                     </div>
                                     <div class="item-content">
                                         <p>{{ with .details }}{{ . | markdownify }}{{ end }}</p>


### PR DESCRIPTION
Similar to a previous PR, this enables users to use markdown for company names - primarily so you can link directly to a company's website. 