### PR TITLE
Improve the print layout

### DIFF
--- a/assets/scss/devresume.scss
+++ b/assets/scss/devresume.scss
@@ -204,6 +204,26 @@ a.resume-link {
     }
 }
 
+@media print {
+  body {
+    -webkit-print-color-adjust: exact;
+  }
+
+  .resume-wrapper {
+    border: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    box-shadow: none !important;
+  }
+
+  .resume-body > .row {
+    display: block; // See https://stackoverflow.com/questions/20408033/how-to-get-page-break-inside-avoid-to-work-nicely-with-flex-wrap-wrap
+  }
+
+  section {
+    break-inside: avoid;
+  }
+}
 
 
 


### PR DESCRIPTION
Improved the print layout of the resume for printing to PDF or paper.

* Remove the outer border
* Prevent page breaks within sections
* Allow printing of background colors and images